### PR TITLE
Enable interactive editing of matrix

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,7 @@
                 <button class="btn btn--secondary filter-btn" data-category="safety_emergency">Safety & Emergency</button>
                 <button class="btn btn--secondary filter-btn" data-category="analytics_reporting">Analytics & Reporting</button>
                 <button class="btn btn--secondary filter-btn" data-category="tournament_competition">Tournament</button>
+                <button id="editToggle" class="btn btn--outline">Edit Mode</button>
             </div>
         </section>
 

--- a/style.css
+++ b/style.css
@@ -1410,6 +1410,14 @@ a:hover {
   font-size: var(--font-size-lg);
 }
 
+.feature-status.editable {
+  cursor: pointer;
+}
+
+.feature-status.editable:hover {
+  background: var(--color-secondary-hover);
+}
+
 .status-icon {
   font-size: var(--font-size-xl);
   font-weight: var(--font-weight-bold);


### PR DESCRIPTION
## Summary
- make data editable by moving competitor data to `defaultData`
- add `Edit Mode` toggle button and editable click handlers
- persist edits in localStorage
- style editable cells with pointer interaction

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6840b048d5348324bd5387e2c673fa39