### PR TITLE
Add inline descriptions to feature matrix

### DIFF
--- a/app.js
+++ b/app.js
@@ -754,11 +754,7 @@ function renderFeatureMatrix() {
       const description = category.features[featureKey];
 
       featureRow.innerHTML = `
-        <div class="feature-name">${label}
-          <span class="info-icon" tabindex="0">i
-            <span class="tooltip">${description}</span>
-          </span>
-        </div>
+        <div class="feature-name"><span class="feature-label">${label}</span><span class="feature-description">${description}</span></div>
         ${['fishbrain', 'infinite_outdoors', 'fishingbooker'].map(cell).join('')}
       `;
       matrixBody.appendChild(featureRow);

--- a/style.css
+++ b/style.css
@@ -1401,6 +1401,15 @@ a:hover {
   font-weight: var(--font-weight-medium);
 }
 
+.feature-label {
+  margin-right: var(--space-8);
+}
+
+.feature-description {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
 .feature-status:last-child {
   border-right: none;
 }
@@ -1435,39 +1444,6 @@ a:hover {
   color: var(--color-error);
 }
 
-/* Info icon tooltip */
-.info-icon {
-  display: inline-block;
-  margin-left: var(--space-4);
-  color: var(--color-info);
-  cursor: pointer;
-  position: relative;
-  font-size: var(--font-size-sm);
-  line-height: 1;
-}
-
-.info-icon .tooltip {
-  display: none;
-  position: absolute;
-  bottom: 125%;
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--color-surface);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  padding: var(--space-8);
-  border-radius: var(--radius-sm);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  white-space: normal;
-  z-index: 10;
-  width: max-content;
-  max-width: 200px;
-}
-
-.info-icon:hover .tooltip,
-.info-icon:focus .tooltip {
-  display: block;
-}
 
 /* Detailed Features */
 .detailed-features {


### PR DESCRIPTION
## Summary
- show feature descriptions inside the comparison matrix
- lighten and style feature descriptions
- remove unused tooltip code

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6840c570ad6c8324bedc0b16600cb9a0