### PR TITLE
Add editable insight titles with extra edit button

### DIFF
--- a/app.js
+++ b/app.js
@@ -648,7 +648,8 @@ function saveData() {
 let matrixBody;
 let categoryScores;
 let filterButtons;
-let editToggleBtn;
+let editToggleBtns;
+let insightTitles;
 
 // Edit mode state
 let editMode = false;
@@ -661,19 +662,24 @@ document.addEventListener('DOMContentLoaded', function() {
   matrixBody = document.getElementById('matrixBody');
   categoryScores = document.getElementById('categoryScores');
   filterButtons = document.querySelectorAll('.filter-btn');
-  editToggleBtn = document.getElementById('editToggle');
+  editToggleBtns = document.querySelectorAll('.edit-toggle');
+  insightTitles = document.querySelectorAll('.insights-grid .card h3');
 
-  if (editToggleBtn) {
-    editToggleBtn.addEventListener('click', function() {
-      editMode = !editMode;
-      this.textContent = editMode ? 'Exit Edit Mode' : 'Edit Mode';
-      renderFeatureMatrix();
+  if (editToggleBtns.length) {
+    editToggleBtns.forEach(btn => {
+      btn.addEventListener('click', function() {
+        editMode = !editMode;
+        updateEditToggleText();
+        renderFeatureMatrix();
+        toggleTitleEditing();
+      });
     });
   }
 
   setupFilterButtons();
   renderFeatureMatrix();
   renderCategoryScores();
+  toggleTitleEditing();
 });
 
 // Setup filter button functionality
@@ -833,4 +839,19 @@ function handleStatusCycle(event) {
   competitorData.competitors[comp].features[category][feature] = next;
   saveData();
   renderFeatureMatrix();
+}
+
+function updateEditToggleText() {
+  if (!editToggleBtns) return;
+  editToggleBtns.forEach(btn => {
+    btn.textContent = editMode ? 'Exit Edit Mode' : 'Edit Mode';
+  });
+}
+
+function toggleTitleEditing() {
+  if (!insightTitles) return;
+  insightTitles.forEach(title => {
+    title.contentEditable = editMode;
+    title.classList.toggle('editable-title', editMode);
+  });
 }

--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
                 <button class="btn btn--secondary filter-btn" data-category="safety_emergency">Safety & Emergency</button>
                 <button class="btn btn--secondary filter-btn" data-category="analytics_reporting">Analytics & Reporting</button>
                 <button class="btn btn--secondary filter-btn" data-category="tournament_competition">Tournament</button>
-                <button id="editToggle" class="btn btn--outline">Edit Mode</button>
+                <button class="btn btn--outline edit-toggle">Edit Mode</button>
             </div>
         </section>
 
@@ -248,7 +248,10 @@
 
         <!-- Strategic Insights Panel -->
         <section class="strategic-insights">
-            <h2>Strategic Development Insights</h2>
+            <div class="insights-header">
+                <h2>Strategic Development Insights</h2>
+                <button class="btn btn--outline edit-toggle">Edit Mode</button>
+            </div>
             <div class="insights-grid">
                 <div class="card">
                     <div class="card__body">

--- a/style.css
+++ b/style.css
@@ -1557,9 +1557,17 @@ a:hover {
 }
 
 /* Strategic Insights */
-.strategic-insights h2 {
-  font-size: var(--font-size-3xl);
+.strategic-insights .insights-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: var(--space-24);
+}
+
+.strategic-insights .insights-header h2 {
+  font-size: var(--font-size-3xl);
+  margin: 0;
+  flex-grow: 1;
   text-align: center;
 }
 
@@ -1573,6 +1581,11 @@ a:hover {
   font-size: var(--font-size-lg);
   margin-bottom: var(--space-16);
   color: var(--color-primary);
+}
+
+.editable-title {
+  cursor: text;
+  border-bottom: 1px dashed var(--color-border);
 }
 
 .insights-grid ul,


### PR DESCRIPTION
## Summary
- make the edit button reusable and place a duplicate in the Strategic Development Insights header
- allow Strategic Development Insights titles to be editable when edit mode is active
- style new header layout and editable titles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840f480b09c8324832590c66b6df20a