### PR TITLE
Allow editing of strategic insight titles

### DIFF
--- a/app.js
+++ b/app.js
@@ -640,6 +640,9 @@ const defaultData = {
 // Load data from localStorage if available
 let competitorData = JSON.parse(localStorage.getItem('competitorData')) || defaultData;
 
+// Load saved strategic insight titles
+let insightTitles = JSON.parse(localStorage.getItem('insightTitles')) || {};
+
 function saveData() {
   localStorage.setItem('competitorData', JSON.stringify(competitorData));
 }
@@ -672,6 +675,7 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   setupFilterButtons();
+  setupInsightTitleEditing();
   renderFeatureMatrix();
   renderCategoryScores();
 });
@@ -691,6 +695,21 @@ function setupFilterButtons() {
       
       // Re-render matrix
       renderFeatureMatrix();
+    });
+  });
+}
+
+// Enable editing for strategic insight titles
+function setupInsightTitleEditing() {
+  const titles = document.querySelectorAll('.insight-title');
+  titles.forEach(title => {
+    const key = title.dataset.key;
+    if (insightTitles[key]) {
+      title.textContent = insightTitles[key];
+    }
+    title.addEventListener('blur', () => {
+      insightTitles[key] = title.textContent.trim();
+      localStorage.setItem('insightTitles', JSON.stringify(insightTitles));
     });
   });
 }

--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@
             <div class="insights-grid">
                 <div class="card">
                     <div class="card__body">
-                        <h3>Market Positioning Analysis</h3>
+                        <h3 class="insight-title" contenteditable="true" data-key="title1">Market Positioning Analysis</h3>
                         <ul>
                             <li><strong>Fishbrain:</strong> Dominates social features with 15M+ users, strong AI capabilities, comprehensive community engagement</li>
                             <li><strong>Infinite Outdoors:</strong> Pioneering private land access model, safety-focused, premium pricing strategy</li>
@@ -262,7 +262,7 @@
                 </div>
                 <div class="card">
                     <div class="card__body">
-                        <h3>Key Integration Opportunities</h3>
+                        <h3 class="insight-title" contenteditable="true" data-key="title2">Key Integration Opportunities</h3>
                         <ul>
                             <li>Social verification + booking systems for enhanced trust and safety</li>
                             <li>AI predictions + private access for optimal fishing experiences</li>
@@ -274,7 +274,7 @@
                 </div>
                 <div class="card">
                     <div class="card__body">
-                        <h3>Priority Features for New AI Platform</h3>
+                        <h3 class="insight-title" contenteditable="true" data-key="title3">Priority Features for New AI Platform</h3>
                         <ol>
                             <li><strong>Advanced AI Engine:</strong> Beyond basic predictions - individual fish recognition, pattern learning</li>
                             <li><strong>Unified Access Management:</strong> Combining public waters, private access, and guide services</li>
@@ -287,7 +287,7 @@
                 </div>
                 <div class="card">
                     <div class="card__body">
-                        <h3>Technology Gap Analysis</h3>
+                        <h3 class="insight-title" contenteditable="true" data-key="title4">Technology Gap Analysis</h3>
                         <ul>
                             <li><strong>AI/ML:</strong> Only Fishbrain has comprehensive AI - major opportunity for advancement</li>
                             <li><strong>Real-time Analytics:</strong> Limited cross-platform analytics and reporting capabilities</li>

--- a/style.css
+++ b/style.css
@@ -1575,6 +1575,15 @@ a:hover {
   color: var(--color-primary);
 }
 
+.insight-title[contenteditable="true"] {
+  cursor: text;
+  border-bottom: 1px dashed var(--color-border);
+}
+
+.insight-title[contenteditable="true"]:focus {
+  outline: var(--focus-outline);
+}
+
 .insights-grid ul,
 .insights-grid ol {
   margin: 0;


### PR DESCRIPTION
## Summary
- allow editing of strategic insight card titles
- persist edited titles in `localStorage`
- style editable titles with dashed underline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840f57cadb483248b6b3db7b9e81b52