### PR TITLE
Add header layout for insights edit button

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,8 +248,10 @@
 
         <!-- Strategic Insights Panel -->
         <section class="strategic-insights">
-            <h2>Strategic Development Insights</h2>
-            <button id="insightsEditToggle" class="btn btn--outline">Edit Insights</button>
+            <div class="strategic-insights-header">
+                <h2>Strategic Development Insights</h2>
+                <button id="insightsEditToggle" class="btn btn--outline">Edit Insights</button>
+            </div>
             <div class="insights-grid">
                 <div class="card">
                     <div class="card__body">

--- a/style.css
+++ b/style.css
@@ -1557,15 +1557,20 @@ a:hover {
 }
 
 /* Strategic Insights */
+.strategic-insights-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-24);
+}
+
 .strategic-insights h2 {
   font-size: var(--font-size-3xl);
-  margin-bottom: var(--space-24);
-  text-align: center;
+  margin: 0;
 }
 
 .strategic-insights #insightsEditToggle {
-  display: block;
-  margin: 0 auto var(--space-20);
+  margin: 0;
 }
 
 .insights-grid {


### PR DESCRIPTION
## Summary
- wrap the Strategic Development Insights heading and button in a flex container
- align the insights edit button to the right

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840f93cf0e08324b5ab60af086bdec0