### PR TITLE
Enable editing of strategic insight titles

### DIFF
--- a/app.js
+++ b/app.js
@@ -644,11 +644,24 @@ function saveData() {
   localStorage.setItem('competitorData', JSON.stringify(competitorData));
 }
 
+function saveInsightTitles() {
+  localStorage.setItem('insightTitles', JSON.stringify(insightTitles));
+}
+
 // DOM elements
 let matrixBody;
 let categoryScores;
 let filterButtons;
 let editToggleBtn;
+
+// Strategic insight titles
+const defaultInsightTitles = {
+  insight1: 'Market Positioning Analysis',
+  insight2: 'Key Integration Opportunities',
+  insight3: 'Priority Features for New AI Platform',
+  insight4: 'Technology Gap Analysis'
+};
+let insightTitles = JSON.parse(localStorage.getItem('insightTitles')) || defaultInsightTitles;
 
 // Edit mode state
 let editMode = false;
@@ -662,12 +675,22 @@ document.addEventListener('DOMContentLoaded', function() {
   categoryScores = document.getElementById('categoryScores');
   filterButtons = document.querySelectorAll('.filter-btn');
   editToggleBtn = document.getElementById('editToggle');
+  const insightHeaders = document.querySelectorAll('.strategic-insights .card h3');
+
+  insightHeaders.forEach((h, idx) => {
+    const id = `insight${idx + 1}`;
+    h.dataset.insightId = id;
+    if (insightTitles[id]) {
+      h.textContent = insightTitles[id];
+    }
+  });
 
   if (editToggleBtn) {
     editToggleBtn.addEventListener('click', function() {
       editMode = !editMode;
       this.textContent = editMode ? 'Exit Edit Mode' : 'Edit Mode';
       renderFeatureMatrix();
+      toggleInsightEditMode(editMode);
     });
   }
 
@@ -833,4 +856,25 @@ function handleStatusCycle(event) {
   competitorData.competitors[comp].features[category][feature] = next;
   saveData();
   renderFeatureMatrix();
+}
+
+function toggleInsightEditMode(enabled) {
+  const insightHeaders = document.querySelectorAll('.strategic-insights .card h3');
+  insightHeaders.forEach(h => {
+    if (enabled) {
+      h.classList.add('editable-heading');
+      h.setAttribute('contenteditable', 'true');
+      h.addEventListener('blur', handleInsightBlur);
+    } else {
+      h.classList.remove('editable-heading');
+      h.removeAttribute('contenteditable');
+      h.removeEventListener('blur', handleInsightBlur);
+    }
+  });
+}
+
+function handleInsightBlur(e) {
+  const id = e.target.dataset.insightId;
+  insightTitles[id] = e.target.textContent.trim();
+  saveInsightTitles();
 }

--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@
             <div class="insights-grid">
                 <div class="card">
                     <div class="card__body">
-                        <h3>Market Positioning Analysis</h3>
+                        <h3 id="insight1">Market Positioning Analysis</h3>
                         <ul>
                             <li><strong>Fishbrain:</strong> Dominates social features with 15M+ users, strong AI capabilities, comprehensive community engagement</li>
                             <li><strong>Infinite Outdoors:</strong> Pioneering private land access model, safety-focused, premium pricing strategy</li>
@@ -262,7 +262,7 @@
                 </div>
                 <div class="card">
                     <div class="card__body">
-                        <h3>Key Integration Opportunities</h3>
+                        <h3 id="insight2">Key Integration Opportunities</h3>
                         <ul>
                             <li>Social verification + booking systems for enhanced trust and safety</li>
                             <li>AI predictions + private access for optimal fishing experiences</li>
@@ -274,7 +274,7 @@
                 </div>
                 <div class="card">
                     <div class="card__body">
-                        <h3>Priority Features for New AI Platform</h3>
+                        <h3 id="insight3">Priority Features for New AI Platform</h3>
                         <ol>
                             <li><strong>Advanced AI Engine:</strong> Beyond basic predictions - individual fish recognition, pattern learning</li>
                             <li><strong>Unified Access Management:</strong> Combining public waters, private access, and guide services</li>
@@ -287,7 +287,7 @@
                 </div>
                 <div class="card">
                     <div class="card__body">
-                        <h3>Technology Gap Analysis</h3>
+                        <h3 id="insight4">Technology Gap Analysis</h3>
                         <ul>
                             <li><strong>AI/ML:</strong> Only Fishbrain has comprehensive AI - major opportunity for advancement</li>
                             <li><strong>Real-time Analytics:</strong> Limited cross-platform analytics and reporting capabilities</li>

--- a/style.css
+++ b/style.css
@@ -1575,6 +1575,16 @@ a:hover {
   color: var(--color-primary);
 }
 
+.editable-heading {
+  cursor: text;
+  border-bottom: 1px dashed var(--color-border);
+}
+
+.editable-heading:focus {
+  outline: none;
+  border-bottom-color: var(--color-primary);
+}
+
 .insights-grid ul,
 .insights-grid ol {
   margin: 0;


### PR DESCRIPTION
## Summary
- make strategic insight headers editable in edit mode
- persist edited titles in localStorage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841c2db6d6c8324b308304f894101cb