### PR TITLE
Add edit button to insights header

### DIFF
--- a/app.js
+++ b/app.js
@@ -652,7 +652,7 @@ function saveInsightTitles() {
 let matrixBody;
 let categoryScores;
 let filterButtons;
-let editToggleBtn;
+let editToggleBtns;
 
 // Strategic insight titles
 const defaultInsightTitles = {
@@ -674,7 +674,7 @@ document.addEventListener('DOMContentLoaded', function() {
   matrixBody = document.getElementById('matrixBody');
   categoryScores = document.getElementById('categoryScores');
   filterButtons = document.querySelectorAll('.filter-btn');
-  editToggleBtn = document.getElementById('editToggle');
+  editToggleBtns = document.querySelectorAll('.edit-toggle');
   const insightHeaders = document.querySelectorAll('.strategic-insights .card h3');
 
   insightHeaders.forEach((h, idx) => {
@@ -685,12 +685,16 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   });
 
-  if (editToggleBtn) {
-    editToggleBtn.addEventListener('click', function() {
-      editMode = !editMode;
-      this.textContent = editMode ? 'Exit Edit Mode' : 'Edit Mode';
-      renderFeatureMatrix();
-      toggleInsightEditMode(editMode);
+  if (editToggleBtns.length) {
+    editToggleBtns.forEach(btn => {
+      btn.addEventListener('click', function() {
+        editMode = !editMode;
+        editToggleBtns.forEach(b => {
+          b.textContent = editMode ? 'Exit Edit Mode' : 'Edit Mode';
+        });
+        renderFeatureMatrix();
+        toggleInsightEditMode(editMode);
+      });
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -248,7 +248,10 @@
 
         <!-- Strategic Insights Panel -->
         <section class="strategic-insights">
-            <h2>Strategic Development Insights</h2>
+            <div class="insights-header">
+                <h2>Strategic Development Insights</h2>
+                <button class="btn btn--outline edit-toggle">Edit Mode</button>
+            </div>
             <div class="insights-grid">
                 <div class="card">
                     <div class="card__body">

--- a/style.css
+++ b/style.css
@@ -1559,8 +1559,18 @@ a:hover {
 /* Strategic Insights */
 .strategic-insights h2 {
   font-size: var(--font-size-3xl);
+}
+
+.insights-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: var(--space-24);
-  text-align: center;
+}
+
+.insights-header h2 {
+  margin: 0;
+  text-align: left;
 }
 
 .insights-grid {


### PR DESCRIPTION
## Summary
- duplicate Edit Mode button beside Strategic Development Insights heading
- style insights header so the button aligns to the right
- support multiple edit buttons in JS initialization

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841c854eb08832490c818bf25133661