### PR TITLE
Enable editing of insight bullets

### DIFF
--- a/app.js
+++ b/app.js
@@ -864,6 +864,7 @@ function handleStatusCycle(event) {
 
 function toggleInsightEditMode(enabled) {
   const insightHeaders = document.querySelectorAll('.strategic-insights .card h3');
+  const insightBullets = document.querySelectorAll('.strategic-insights li');
   insightHeaders.forEach(h => {
     if (enabled) {
       h.classList.add('editable-heading');
@@ -877,6 +878,18 @@ function toggleInsightEditMode(enabled) {
       h.removeEventListener('keydown', handleInsightKeydown);
     }
   });
+
+  insightBullets.forEach(li => {
+    if (enabled) {
+      li.classList.add('editable-bullet');
+      li.setAttribute('contenteditable', 'true');
+      li.addEventListener('keydown', handleBulletKeydown);
+    } else {
+      li.classList.remove('editable-bullet');
+      li.removeAttribute('contenteditable');
+      li.removeEventListener('keydown', handleBulletKeydown);
+    }
+  });
 }
 
 function handleInsightBlur(e) {
@@ -886,6 +899,13 @@ function handleInsightBlur(e) {
 }
 
 function handleInsightKeydown(e) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    e.target.blur();
+  }
+}
+
+function handleBulletKeydown(e) {
   if (e.key === 'Enter') {
     e.preventDefault();
     e.target.blur();

--- a/style.css
+++ b/style.css
@@ -1595,6 +1595,16 @@ a:hover {
   border-bottom-color: var(--color-primary);
 }
 
+.editable-bullet {
+  cursor: text;
+  border-bottom: 1px dashed var(--color-border);
+}
+
+.editable-bullet:focus {
+  outline: none;
+  border-bottom-color: var(--color-primary);
+}
+
 .insights-grid ul,
 .insights-grid ol {
   margin: 0;


### PR DESCRIPTION
## Summary
- allow editing list items within Strategic Development Insights when Edit Mode is active
- style editable bullets similar to editable headings

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6841cca7b0648324b80b7ec76aa7c285