### PR TITLE
Enable dynamic category scores with gap analysis

### DIFF
--- a/app.js
+++ b/app.js
@@ -812,48 +812,65 @@ function renderFeatureMatrix() {
 }
 
 
-// Calculate category scores
+// Feature score helper
+function getFeatureScore(value) {
+  if (value === true || value === 'full') return 1;
+  if (value === 'partial' || value === 'premium') return 0.5;
+  return 0;
+}
+
+// Calculate category score for a competitor
 function calculateCategoryScore(categoryKey, competitorKey) {
   const features = competitorData.competitors[competitorKey].features[categoryKey];
-  const totalFeatures = Object.keys(features).length;
-  
-  let score = 0;
-  Object.values(features).forEach(value => {
-    if (value === true) score += 1;
-    else if (value === 'premium' || value === 'partial') score += 0.5;
+  const featureIds = Object.keys(features);
+  let total = 0;
+  featureIds.forEach(fid => {
+    total += getFeatureScore(features[fid]);
   });
-  
-  return Math.round((score / totalFeatures) * 100);
+  return Math.round((total / featureIds.length) * 100);
+}
+
+// Calculate gap across competitors
+function calculateCategoryGap(categoryKey) {
+  const competitors = ['fishbrain', 'infinite_outdoors', 'fishingbooker'];
+  const scores = competitors.map(c => calculateCategoryScore(categoryKey, c));
+  const max = Math.max(...scores);
+  const min = Math.min(...scores);
+  return { max, min, gap: max - min };
 }
 
 // Render category scores
 function renderCategoryScores() {
   if (!categoryScores) return;
 
+  categoryScores.innerHTML = '';
   const categories = competitorData.feature_categories;
   const competitors = ['fishbrain', 'infinite_outdoors', 'fishingbooker'];
 
   Object.keys(categories).forEach(categoryKey => {
     const category = categories[categoryKey];
-    
+
     const scoreDiv = document.createElement('div');
     scoreDiv.className = 'category-score';
-    
+
     const scores = competitors.map(comp => calculateCategoryScore(categoryKey, comp));
-    const avgScore = Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
-    
-    let scoreClass = 'low';
-    if (avgScore >= 70) scoreClass = 'high';
-    else if (avgScore >= 40) scoreClass = 'medium';
-    
-    scoreDiv.innerHTML = `
-      <span>${category.name}</span>
-      <div class="score-bar">
-        <div class="score-fill ${scoreClass}" style="width: ${avgScore}%"></div>
-      </div>
-      <span>${avgScore}%</span>
-    `;
-    
+    const gapData = calculateCategoryGap(categoryKey);
+
+    let cells = `<span>${category.name}</span>`;
+    scores.forEach(score => {
+      let cls = 'low';
+      if (score >= 70) cls = 'high';
+      else if (score >= 40) cls = 'medium';
+      cells += `
+        <div class="competitor-score">
+          <div class="score-bar"><div class="score-fill ${cls}" style="width: ${score}%"></div></div>
+          <span>${score}%</span>
+        </div>`;
+    });
+
+    cells += `<span class="gap-label">Gap: ${gapData.gap}%</span>`;
+    scoreDiv.innerHTML = cells;
+
     categoryScores.appendChild(scoreDiv);
   });
 }
@@ -884,6 +901,7 @@ function handleStatusCycle(event) {
   competitorData.competitors[comp].features[category][feature] = next;
   saveData();
   renderFeatureMatrix();
+  renderCategoryScores();
 }
 
 function toggleInsightEditMode(enabled) {

--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
                 <div class="card">
                     <div class="card__body">
                         <h3>Category Completion Scores</h3>
-                        <p class="score-description">Average implementation across all competitors by category</p>
+                        <p class="score-description">Completion by competitor with category gap</p>
                         <div class="category-scores" id="categoryScores">
                             <!-- Scores will be populated by JavaScript -->
                         </div>

--- a/style.css
+++ b/style.css
@@ -1476,9 +1476,10 @@ a:hover {
 }
 
 .category-score {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr auto;
   align-items: center;
+  gap: var(--space-12);
   padding: var(--space-8) 0;
   border-bottom: 1px solid var(--color-border);
 }
@@ -1512,6 +1513,21 @@ a:hover {
 
 .score-fill.low {
   background: var(--color-error);
+}
+
+.competitor-score {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+}
+
+.competitor-score .score-bar {
+  margin-left: 0;
+}
+
+.gap-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
 }
 
 .opportunity {


### PR DESCRIPTION
## Summary
- compute feature scores with `getFeatureScore`
- calculate per-competitor category completion and gap
- render a progress bar for every competitor and display gap percentage
- refresh category scores when features are edited
- style updates for multi-column category progress layout
- clarify gap analysis description

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6842f674bc348324b6837f2fbc6d84c1