### PR TITLE
Adjust width of category completion scores

### DIFF
--- a/style.css
+++ b/style.css
@@ -1459,7 +1459,7 @@ a:hover {
 
 .gap-analysis-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 2fr 1fr;
   gap: var(--space-20);
 }
 


### PR DESCRIPTION
## Summary
- widen the gap analysis grid so the category completion scores card has more room

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842fad1c0b48324b8d5b78a6123c666