### PR TITLE
Increase width of analysis dashboard

### DIFF
--- a/style.css
+++ b/style.css
@@ -98,7 +98,7 @@
   --container-sm: 640px;
   --container-md: 768px;
   --container-lg: 1024px;
-  --container-xl: 1280px;
+  --container-xl: 1600px;
 }
 
 /* Dark mode colors */
@@ -753,7 +753,7 @@ select.form-control {
   --container-sm: 640px;
   --container-md: 768px;
   --container-lg: 1024px;
-  --container-xl: 1280px;
+  --container-xl: 1600px;
 }
 
 /* Dark mode colors */


### PR DESCRIPTION
## Summary
- widen the `container-xl` layout to 1600px so the category completion scores card has more room

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842fca13144832498d9e590fba8a3ef