### PR TITLE
Add competitor headers to category score section

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,6 +211,13 @@
                     <div class="card__body">
                         <h3>Category Completion Scores</h3>
                         <p class="score-description">Completion by competitor with category gap</p>
+                        <div class="category-score-header">
+                            <div>Category</div>
+                            <div>Fishbrain</div>
+                            <div>Infinite Outdoors</div>
+                            <div>FishingBooker</div>
+                            <div>Gap</div>
+                        </div>
                         <div class="category-scores" id="categoryScores">
                             <!-- Scores will be populated by JavaScript -->
                         </div>

--- a/style.css
+++ b/style.css
@@ -1475,6 +1475,24 @@ a:hover {
   margin-bottom: var(--space-16);
 }
 
+.category-score-header {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr auto;
+  background: var(--color-secondary);
+  font-weight: var(--font-weight-semibold);
+  gap: var(--space-12);
+  padding: var(--space-8) 0;
+  border-bottom: 2px solid var(--color-border);
+}
+
+.category-score-header > div {
+  text-align: center;
+}
+
+.category-score-header > div:first-child {
+  text-align: left;
+}
+
 .category-score {
   display: grid;
   grid-template-columns: 2fr 1fr 1fr 1fr auto;


### PR DESCRIPTION
## Summary
- show competitor names above the category completion score progress bars
- style new category score header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842feeb7df48324853c9ad063497fbd