### PR TITLE
Add competitor headers to category score section

### DIFF
--- a/app.js
+++ b/app.js
@@ -843,7 +843,14 @@ function calculateCategoryGap(categoryKey) {
 function renderCategoryScores() {
   if (!categoryScores) return;
 
-  categoryScores.innerHTML = '';
+  categoryScores.innerHTML = `
+    <div class="category-score-header">
+      <div>Category</div>
+      <div>Fishbrain</div>
+      <div>Infinite Outdoors</div>
+      <div>FishingBooker</div>
+      <div>Gap</div>
+    </div>`;
   const categories = competitorData.feature_categories;
   const competitors = ['fishbrain', 'infinite_outdoors', 'fishingbooker'];
 

--- a/style.css
+++ b/style.css
@@ -1475,6 +1475,24 @@ a:hover {
   margin-bottom: var(--space-16);
 }
 
+.category-score-header {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr auto;
+  background: var(--color-secondary);
+  font-weight: var(--font-weight-semibold);
+  gap: var(--space-12);
+  padding: var(--space-8) 0;
+  border-bottom: 2px solid var(--color-border);
+}
+
+.category-score-header > div {
+  text-align: center;
+}
+
+.category-score-header > div:first-child {
+  text-align: left;
+}
+
 .category-score {
   display: grid;
   grid-template-columns: 2fr 1fr 1fr 1fr auto;


### PR DESCRIPTION
## Summary
- show competitor headers inside the category scores grid
- inject headers dynamically when rendering category completion scores

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842feeb7df48324853c9ad063497fbd