### PR TITLE
Fix duplicated category completion header

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,13 +211,6 @@
                     <div class="card__body">
                         <h3>Category Completion Scores</h3>
                         <p class="score-description">Completion by competitor with category gap</p>
-                        <div class="category-score-header">
-                            <div>Category</div>
-                            <div>Fishbrain</div>
-                            <div>Infinite Outdoors</div>
-                            <div>FishingBooker</div>
-                            <div>Gap</div>
-                        </div>
                         <div class="category-scores" id="categoryScores">
                             <!-- Scores will be populated by JavaScript -->
                         </div>


### PR DESCRIPTION
## Summary
- remove the hardcoded `category-score-header` in `index.html` to avoid double rendering

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684306f97e5c832494c2bc184df500b2