### PR TITLE
Center justify score headers

### DIFF
--- a/style.css
+++ b/style.css
@@ -1486,10 +1486,13 @@ a:hover {
 }
 
 .category-score-header > div {
+  display: flex;
+  justify-content: center;
   text-align: center;
 }
 
 .category-score-header > div:first-child {
+  justify-content: flex-start;
   text-align: left;
 }
 


### PR DESCRIPTION
## Summary
- center align category score table headers using flexbox

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684308d9a0e083248f678fcbf253764e