### PR TITLE
Center completion headers

### DIFF
--- a/style.css
+++ b/style.css
@@ -1478,6 +1478,7 @@ a:hover {
 .category-score-header {
   display: grid;
   grid-template-columns: 2fr 1fr 1fr 1fr auto;
+  justify-items: center;
   background: var(--color-secondary);
   font-weight: var(--font-weight-semibold);
   gap: var(--space-12);
@@ -1486,16 +1487,23 @@ a:hover {
 }
 
 .category-score-header > div {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
   text-align: center;
+  white-space: nowrap;
 }
 
 .category-score-header > div:first-child {
+  justify-content: flex-start;
   text-align: left;
 }
 
 .category-score {
   display: grid;
   grid-template-columns: 2fr 1fr 1fr 1fr auto;
+  justify-items: center;
   align-items: center;
   gap: var(--space-12);
   padding: var(--space-8) 0;
@@ -1536,6 +1544,7 @@ a:hover {
 .competitor-score {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: var(--space-8);
 }
 


### PR DESCRIPTION
## Summary
- ensure headers and scores in category completion table align with `justify-items: center`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684308d9a0e083248f678fcbf253764e