### PR TITLE
Fix alignment for Category Completion section

### DIFF
--- a/style.css
+++ b/style.css
@@ -1457,6 +1457,10 @@ a:hover {
   text-align: center;
 }
 
+.gap-analysis .card h3 {
+  text-align: left;
+}
+
 .gap-analysis-grid {
   display: grid;
   grid-template-columns: 2fr 1fr;
@@ -1484,6 +1488,7 @@ a:hover {
   gap: var(--space-12);
   padding: var(--space-8) 0;
   border-bottom: 2px solid var(--color-border);
+  text-align: left;
 }
 
 .category-score-header > div {
@@ -1503,6 +1508,7 @@ a:hover {
   gap: var(--space-12);
   padding: var(--space-8) 0;
   border-bottom: 1px solid var(--color-border);
+  text-align: left;
 }
 
 .category-score:last-child {


### PR DESCRIPTION
## Summary
- left-align the Category Completion Scores header and rows
- ensure card headings in the gap analysis section are left justified

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684318d1d45c8324836dbb9f71e4c857