### PR TITLE
Add spacing for Strategic Market Opportunities heading

### DIFF
--- a/style.css
+++ b/style.css
@@ -1459,6 +1459,7 @@ a:hover {
 
 .gap-analysis .card h3 {
   text-align: left;
+  margin-bottom: var(--space-16);
 }
 
 .gap-analysis-grid {


### PR DESCRIPTION
## Summary
- add bottom margin to `.gap-analysis .card h3` so the first strategic opportunity isn't crowded against the heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68431ae763e883249b1a6f1867e5ee37